### PR TITLE
Remove deprecation silencing

### DIFF
--- a/lib/wisper/activerecord/publisher.rb
+++ b/lib/wisper/activerecord/publisher.rb
@@ -16,11 +16,8 @@ module Wisper
       included do
         include Wisper::Publisher
 
-        # NOTE: do not need to silence deprecations on Rails 5+
-        ActiveSupport::Deprecation.silence do
-          VALID_BROADCAST_EVENTS.each do |event_name|
-            after_commit "broadcast_#{event_name}".to_sym, on: event_name, if: -> { should_broadcast?(event_name) }
-          end
+        VALID_BROADCAST_EVENTS.each do |event_name|
+          after_commit "broadcast_#{event_name}".to_sym, on: event_name, if: -> { should_broadcast?(event_name) }
         end
 
         class_attribute :wisper_activerecord_publisher_broadcast_events

--- a/lib/wisper/activerecord/publisher/version.rb
+++ b/lib/wisper/activerecord/publisher/version.rb
@@ -1,7 +1,7 @@
 module Wisper
   module Activerecord
     module Publisher
-      VERSION = '0.2.0'.freeze
+      VERSION = '0.3.0'.freeze
     end
   end
 end

--- a/wisper-activerecord-publisher.gemspec
+++ b/wisper-activerecord-publisher.gemspec
@@ -19,11 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'wisper'
-  spec.add_runtime_dependency 'activerecord'
+  spec.add_runtime_dependency 'activerecord', '>= 5.0'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency "sqlite3"
-
-  spec.add_dependency 'rails', '>= 5.0'
 end

--- a/wisper-activerecord-publisher.gemspec
+++ b/wisper-activerecord-publisher.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency "sqlite3"
+
+  spec.add_dependency 'rails', '>= 5.0'
 end


### PR DESCRIPTION
This is for [DSO-4216](https://betterup.atlassian.net/issues/DSO-4216) - we need to remove deprecation silencing so that we can upgrade to Rails 7.2